### PR TITLE
Lower file descriptor consumption

### DIFF
--- a/webextaware/main.py
+++ b/webextaware/main.py
@@ -68,7 +68,9 @@ def main():
 
     # Adjust file limits
     from_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
-    to_limit = (10000, from_limit[1])
+    (soft_limit, hard_limit) = from_limit
+    soft_limit = min(10000, hard_limit)
+    to_limit = (soft_limit, hard_limit)
     logger.debug("Raising open file limit from %s to %s" % (repr(from_limit), repr(to_limit)))
     resource.setrlimit(resource.RLIMIT_NOFILE, to_limit)
 


### PR DESCRIPTION
I tried to use your project, and initially it failed to run at all because the hard-coded file descriptor soft limit was lower than the allowed hard limit. I fixed this in the first commit.

Then I was wondering why the program needs so many file descriptors. The second commit minimizes the file descriptor usage by re-using connections, and now I have managed to sync the whole database with at most 30 file descriptors (arbitrarily chosen number for testing, can be even less).

With the second change, the rlimit hack and the mentioning of the "Too many open files" error in the README is probably not needed. If you want to, you can remove those yourself.

Tested with Python 3.6.2 on ArchLinux.