### PR TITLE
Minimize lifetime of ZipFile file descriptor

### DIFF
--- a/tests/webext_test.py
+++ b/tests/webext_test.py
@@ -20,7 +20,7 @@ def test_webext_object():
             assert_true("manifest.json" in w.ls(), "each has manifest.json")
             manifest = w.manifest()
             assert_true(type(manifest) is we.Manifest, "can yield Manifest objects")
-            zipped_names = [z.filename for f, z in w.zipped_files()]
+            zipped_names = w.ls()
             assert_true("manifest.json" in zipped_names, "manifest.json is among zipped_files")
 
 


### PR DESCRIPTION
I tried `webextaware unzip all` and came short on file descriptors. This PR fixes the issue.

```
Traceback (most recent call last):
  File "/home/webextaware/.local/bin/webextaware", line 11, in <module>
  File "/home/webextaware/_webextaware.git/webextaware/main.py", line 78, in main
  File "/home/webextaware/_webextaware.git/webextaware/modes/runmode.py", line 127, in run
  File "/home/webextaware/_webextaware.git/webextaware/modes/unzip.py", line 46, in run
  File "/home/webextaware/_webextaware.git/webextaware/webext.py", line 69, in unzip
  File "/usr/lib/python3.6/zipfile.py", line 1501, in extractall
  File "/usr/lib/python3.6/zipfile.py", line 1555, in _extract_member
OSError: [Errno 24] Too many open files: '/tmp/ext/847939/5c4dcebca49742a9846cb01c9e8e4d630548a7a40d6e56626b6009f78a2c85da/META-INF/mozilla.rsa'
```