### PR TITLE
Improving speed by parallelization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ venv
 .idea/
 __pycache__/
 webextaware.egg-info/
+.eggs/
 node_modules
 webext_hashfs

--- a/README.md
+++ b/README.md
@@ -120,10 +120,13 @@ Grep for a regular expression in all or specific extensions with
 
 ```
 webextaware grep optional_permissions
-webextaware grep -- -A5 optional_permissions 739662
+webextaware grep optional_permissions 739662 -A 10
 ```
 
-You can pass arguments to grep after a double dash.
+The `grep` subcommand is equivalent to `grep -E <args> -r <extension dir>`.
+Any arguments following the regular expression and package selectors will be
+passed transparently to grep. If you need more fancy grepping capabilities or a
+huge performance boost, consider to `webextaware unzip all` first.
 
 ### scan
 
@@ -134,3 +137,15 @@ webextaware scan 739662
 ```
 
 The result is formatted in JSON.
+
+### libs
+
+Get some framework / libraries statistics with
+
+```
+webextaware libs amazon -e
+webextaware libs -H
+```
+
+The former syntax provides the data in JSON format and groups libraries per extension.
+The latter syntax provides complete library statistics in a human-readable format.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup, find_packages
 
 PACKAGE_NAME = "webextaware"
-PACKAGE_VERSION = "1.1.0"
+PACKAGE_VERSION = "1.2.0"
 
 INSTALL_REQUIRES = [
     "coloredlogs",

--- a/webextaware/database.py
+++ b/webextaware/database.py
@@ -82,7 +82,7 @@ class Database(object):
                 selection[amo_id].add(selector)
             else:
                 try:
-                    m = re.compile(selector)
+                    m = re.compile(selector, re.IGNORECASE)
                 except re.error:
                     logger.error("Invalid selector `%s`" % selector)
                     continue

--- a/webextaware/modes/__init__.py
+++ b/webextaware/modes/__init__.py
@@ -5,6 +5,7 @@
 from . import get
 from . import grep
 from . import info
+from . import libs
 from . import manifest
 from . import meta
 from . import query

--- a/webextaware/modes/get.py
+++ b/webextaware/modes/get.py
@@ -23,11 +23,10 @@ class GetMode(RunMode):
         parser.add_argument("selectors",
                             metavar="selector",
                             nargs="+",
-                            action="append",
-                            help="AMO IDs, extension IDs, regexp, `all`, `orphans`")
+                            help="AMO IDs, extension IDs, regexp, `orphans`, `all`")
 
     def run(self):
-        matches = self.db.match(self.args.selectors[0])
+        matches = self.db.match(self.args.selectors)
         if len(matches) == 0:
             logger.warning("No results")
             return 10

--- a/webextaware/modes/grep.py
+++ b/webextaware/modes/grep.py
@@ -2,7 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import argparse
 import logging
+from multiprocessing import Pool
 import os
 import sys
 
@@ -23,11 +25,19 @@ class GrepMode(RunMode):
 
     @staticmethod
     def setup_args(parser):
-        parser.add_argument("modeargs",
-                            metavar="modearg",
-                            nargs="+",
-                            action="append",
-                            help="grep arguments")
+        parser.add_argument("regexp",
+                            action="store",
+                            help="regular expression for `grep -E`")
+
+        parser.add_argument("selectors",
+                            metavar="selector",
+                            nargs="*",
+                            default=["all"],
+                            help="AMO IDs, extension IDs, regexp, `orphans`, `all` (default)")
+
+        parser.add_argument('grepargs',
+                            nargs=argparse.REMAINDER,
+                            help="additional arguments for `grep -E`")
 
     def setup(self):
         if not super().setup():
@@ -39,40 +49,57 @@ class GrepMode(RunMode):
         return True
 
     def run(self):
-        where = []
-        # For now assume every trailing numeric argument is an AMO ID
-        for amo_id in reversed(self.args.modeargs[0]):
-            if amo_id == "*":
-                where.append("all")
-                break
-            elif amo_id.isdigit():
-                where.append(int(amo_id))
-            else:
-                break
-        grep_args = self.args.modeargs[0][:len(self.args.modeargs[0])-len(where)]
-        if len(where) == 0:
-            where = ["all"]
-        logger.debug("Grep args: %s" % grep_args)
-        logger.debug("Grepping in %s" % where)
-        if "all" in where:
-            search_ids = [ext["id"] for ext in self.meta]
-        else:
-            search_ids = where
-        color = sys.stdout.isatty()
-        for amo_id in search_ids:
-            ext = self.meta.get_by_id(amo_id)
-            if ext is not None:
-                for f in ext["current_version"]["files"]:
-                    hash_id = f["hash"].split(":")[1]
-                    archive_path_ref = self.files.get(hash_id)
-                    if archive_path_ref is None:
-                        logger.warning("Missing zip file for ID %s, %s" % (amo_id, hash_id))
-                    else:
-                        we = webext.WebExtension(archive_path_ref.abspath)
-                        try:
-                            package_id = "%s%s%s" % (amo_id, os.path.sep, hash_id)
-                            for line in we.grep(grep_args, color=color):
-                                print(line.replace("<%= PACKAGE_ID %>", package_id))
-                        finally:
-                            we.cleanup()
+        matches = self.db.match(self.args.selectors)
+        if len(matches) == 0:
+            logger.warning("No results")
+            return 10
+
+        work_list = [(amo_id, ext_id) for amo_id in matches for ext_id in matches[amo_id]]
+        for amo_id, ext_id, lines in parallel_grep(work_list, self):
+            if lines is None:
+                continue
+            for line in lines:
+                print(line)
+
         return 0
+
+
+mp_mode = None
+
+
+def parallel_grep(work_list, mode):
+    global mp_mode
+    mp_mode = mode
+    work_len = len(work_list)
+    with Pool() as p:
+        results = p.imap_unordered(grep, work_list)
+        done = 0
+        for result in results:
+            done += 1
+            if done % 500 == 0:
+                logger.info("Progress: %d/%d (%.1f%%)" % (done, work_len, 100.0 * done / work_len))
+            yield result
+
+
+def grep(work_item):
+    global mp_mode
+    amo_id, ext_id = work_item
+    try:
+        ext = mp_mode.db.get_ext(ext_id)[amo_id][ext_id]
+    except KeyError:
+        logger.debug("Missing cache file for %d - %s" % (amo_id, ext_id))
+        return amo_id, ext_id, None
+    file_ref = mp_mode.files.get(ext_id)
+    if file_ref is None:
+        logger.warning("Cache miss for ID %d - %s" % (amo_id, ext_id))
+        return amo_id, ext_id, None
+
+    logger.debug("Grepping in %s, %s" % (amo_id, ext_id))
+    lines = []
+    try:
+        package_id = "%s%s%s" % (amo_id, os.path.sep, ext_id)
+        for line in ext.grep(mp_mode.args.regexp, mp_mode.args.grepargs, color=sys.stdout.isatty()):
+            lines.append(line.replace("<%= PACKAGE_ID %>", package_id))
+    finally:
+        ext.cleanup()
+    return amo_id, ext_id, lines

--- a/webextaware/modes/libs.py
+++ b/webextaware/modes/libs.py
@@ -1,0 +1,217 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import logging
+from multiprocessing import Pool
+import os
+import pkg_resources as pkgr
+import pynpm
+import shutil
+
+from .runmode import RunMode
+from .. import scanner
+
+
+logger = logging.getLogger(__name__)
+
+
+class LibsMode(RunMode):
+    """
+    Mode to detect libraries and frameworks
+    """
+
+    name = "libs"
+    help = "collect statistics on libraries and frameworks"
+
+    @staticmethod
+    def setup_args(parser):
+        parser.add_argument("-e", "--perext",
+                            action="store_true",
+                            help="use web extension-centric output format")
+
+        parser.add_argument("-H", "--human",
+                            action="store_true",
+                            help="print human-readable output format")
+
+        parser.add_argument("selectors",
+                            metavar="selector",
+                            nargs="*",
+                            default=["all"],
+                            help="AMO IDs, extension IDs, regexp, `orphans`, `all` (default)")
+
+    def run(self):
+        node_dir = check_npm_install(self.args)
+        if node_dir is None:
+            return 5
+        matches = self.db.match(self.args.selectors)
+        if len(matches) == 0:
+            logger.warning("No results")
+            return 10
+
+        retire_instance = scanner.RetireScanner(node_dir=node_dir)
+        if not retire_instance.dependencies():
+            return 20
+
+        work_list = [(amo_id, ext_id) for amo_id in matches for ext_id in matches[amo_id]]
+        results = {}
+        for amo_id, ext_id, result in parallel_scan(work_list, self, retire_instance):
+            if amo_id not in results:
+                results[amo_id] = {}
+            if ext_id not in results[amo_id]:
+                results[amo_id][ext_id] = {}
+            results[amo_id][ext_id] = result
+
+        if self.args.perext:
+            if self.args.human:
+                logger.warning("Human-readable output not implemented for per-extension results")
+            print(json.dumps(results, indent=4))
+
+        else:
+            components = by_components(results)
+
+            if not self.args.human:
+                print(json.dumps(components, indent=4))
+
+            else:
+                # severity_rating = ["-", "low", "medium", "high"]
+                aggregate = aggregate_counts(components)
+                amo_count = len(matches)
+                ext_count = sum([len(matches[amo_id]) for amo_id in matches])
+                for component in sorted(aggregate.keys()):
+                    for version in sorted(aggregate[component].keys()):
+                        print("%40s\t%-15s\t%7d (%.1f%%)\t%7d (%.1f%%)" % (
+                            component,
+                            version,
+                            aggregate[component][version]["amo_ids"],
+                            aggregate[component][version]["amo_ids"] * 100.0 / amo_count,
+                            aggregate[component][version]["ext_ids"],
+                            aggregate[component][version]["ext_ids"] * 100.0 / ext_count
+                        ))
+
+        return 0
+
+
+def check_npm_install(args):
+    node_dir = os.path.join(args.workdir, "node")
+    os.makedirs(node_dir, exist_ok=True)
+    package_json = os.path.join(node_dir, "package.json")
+    module_package_json = pkgr.resource_filename("webextaware", "package.json")
+    if not os.path.exists(package_json) \
+            or os.path.getmtime(package_json) < os.path.getmtime(module_package_json):
+        shutil.copyfile(module_package_json, package_json)
+        try:
+            npm_pkg = pynpm.NPMPackage(os.path.abspath(package_json))
+            npm_pkg.install()
+        except FileNotFoundError:
+            logger.critical("Node Package Manager not found")
+            os.unlink(package_json)  # To trigger reinstall
+            return None
+    return node_dir
+
+
+def sub_versions(version):
+    subs = version.split(".")
+    for i in range(len(subs)):
+        yield ".".join(subs[:i+1])
+
+
+mp_mode = None
+mp_scanner = None
+
+
+def parallel_scan(work_list, mode, scanner_instance):
+    global mp_mode, mp_scanner
+    mp_mode = mode
+    mp_scanner = scanner_instance
+    work_len = len(work_list)
+    with Pool() as p:
+        results = p.imap_unordered(scan, work_list)
+        done = 0
+        for result in results:
+            if done % 100 == 0:
+                logger.info("Progress: %d/%d (%.1f%%)" % (done, work_len, 100.0 * done / work_len))
+            done += 1
+            yield result
+
+
+def scan(work_item):
+    global mp_mode, mp_scanner
+    amo_id, ext_id = work_item
+    try:
+        ext = mp_mode.db.get_ext(ext_id)[amo_id][ext_id]
+    except KeyError:
+        logger.debug("Missing cache file for %s - %s" % (amo_id, ext_id))
+        return amo_id, ext_id, None
+    file_ref = mp_mode.files.get(ext_id)
+    if file_ref is None:
+        logger.warning("Cache miss for ID %d - %s" % (amo_id, ext_id))
+        return amo_id, ext_id, None
+
+    logger.debug("Running %s scan on %s, %s" % (mp_scanner.name, amo_id, ext_id))
+    mp_scanner.scan(extension=ext, verbose=True)
+    return amo_id, ext_id, mp_scanner.result
+
+
+def by_components(results):
+    components = {}
+    for amo_id in results:
+        for ext_id in results[amo_id]:
+            if results[amo_id][ext_id] is None:
+                continue
+            for detection in results[amo_id][ext_id]:
+                if "results" in detection:
+                    # This is a regular result with `file` and `results` keys
+                    for result in detection["results"]:
+                        c_name = result["component"]
+                        c_version = result["version"]
+                        if c_name not in components:
+                            components[c_name] = {}
+                        component = components[c_name]
+                        if c_version not in component:
+                            component[c_version] = {}
+                            component[c_version].update(result)
+                            if "detection" in component[c_version]:
+                                del component[c_version]["detection"]
+                            component[c_version]["matches"] = {}
+                        if amo_id not in component[c_version]["matches"]:
+                            component[c_version]["matches"][amo_id] = {}
+                        if ext_id not in component[c_version]["matches"][amo_id]:
+                            component[c_version]["matches"][amo_id][ext_id] = []
+                        component[c_version]["matches"][amo_id][ext_id].append(detection["file"])
+                else:
+                    # This is a file-less result with just `component` and `version`
+                    for d in detection:
+                        c_name = d["component"]
+                        c_version = d["version"]
+                        if c_name not in components:
+                            components[c_name] = {}
+                        if c_version not in components[c_name]:
+                            components[c_name][c_version] = {}
+                            components[c_name][c_version].update(d)
+                            components[c_name][c_version]["matches"] = {}
+                        if amo_id not in components[c_name][c_version]["matches"]:
+                            components[c_name][c_version]["matches"][amo_id] = {}
+                        if ext_id not in components[c_name][c_version]["matches"][amo_id]:
+                            components[c_name][c_version]["matches"][amo_id][ext_id] = []
+                        components[c_name][c_version]["matches"][amo_id][ext_id].append(None)
+    return components
+
+
+def aggregate_counts(components):
+    aggregate = {}
+    for c_name in components:
+        aggregate[c_name] = {}
+        for c_version in components[c_name]:
+            for v in sub_versions(c_version):
+                if v not in aggregate[c_name]:
+                    aggregate[c_name][v] = {
+                        "amo_ids": 0,
+                        "ext_ids": 0
+                    }
+                for amo_id in components[c_name][c_version]["matches"]:
+                    aggregate[c_name][v]["amo_ids"] += 1
+                    aggregate[c_name][v]["ext_ids"] += \
+                        len(components[c_name][c_version]["matches"][amo_id])
+    return aggregate

--- a/webextaware/modes/manifest.py
+++ b/webextaware/modes/manifest.py
@@ -33,8 +33,7 @@ class MetadataMode(RunMode):
         parser.add_argument("selectors",
                             metavar="selector",
                             nargs="+",
-                            action="append",
-                            help="AMO IDs, extension IDs, regexp, `all`, `orphans`")
+                            help="AMO IDs, extension IDs, regexp, `orphans`, `all`")
 
     @staticmethod
     def check_args(args):
@@ -47,7 +46,7 @@ class MetadataMode(RunMode):
     def run(self):
         global logger
 
-        exts = self.db.get_ext(self.args.selectors[0])
+        exts = self.db.get_ext(self.args.selectors)
         if len(exts) == 0:
             logger.warning("No results")
             return 10

--- a/webextaware/modes/meta.py
+++ b/webextaware/modes/meta.py
@@ -23,13 +23,13 @@ class MetaaMode(RunMode):
     def setup_args(parser):
         parser.add_argument("selectors",
                             metavar="selector",
-                            nargs="+",
-                            action="append",
-                            help="AMO IDs, extension IDs, regexp, `all`, `orphans`")
+                            nargs="*",
+                            default=["all"],
+                            help="AMO IDs, extension IDs, regexp, `orphans`, `all` (default)")
 
     def run(self):
         result = 0
-        meta = self.db.get_meta(self.args.selectors[0])
+        meta = self.db.get_meta(self.args.selectors)
         if len(meta) == 0:
             logger.warning("No results")
             result = 10

--- a/webextaware/modes/query.py
+++ b/webextaware/modes/query.py
@@ -24,11 +24,10 @@ class QueryMode(RunMode):
         parser.add_argument("ids",
                             metavar="selector",
                             nargs="+",
-                            action="append",
-                            help="AMO IDs, extension IDs, regexp, `all`, `orphans`")
+                            help="AMO IDs, extension IDs, regexp, `orphans`, `all`")
 
     def run(self):
-        matches = self.db.match(self.args.ids[0])
+        matches = self.db.match(self.args.ids)
         if len(matches) == 0:
             logger.warning("No results")
             return 10

--- a/webextaware/modes/shell.py
+++ b/webextaware/modes/shell.py
@@ -31,15 +31,15 @@ class ShellMode(RunMode):
         parser.add_argument("selectors",
                             metavar="selector",
                             nargs="*",
-                            action="append",
-                            help="AMO IDs, extension IDs, regexp, `all`, `orphans`")
+                            default=["all"],
+                            help="AMO IDs, extension IDs, regexp, `orphans`, `all` (default)")
 
     def run(self):
 
-        if len(self.args.selectors[0]) == 0:
-            matches = self.db.match("all")
-        else:
-            matches = self.db.match(self.args.ids[0])
+        matches = self.db.match(self.args.selectors)
+        if len(matches) == 0:
+            logger.warning("No results")
+            return 10
 
         # Just for convenience
         meta = self.meta

--- a/webextaware/modes/sync.py
+++ b/webextaware/modes/sync.py
@@ -33,7 +33,7 @@ class SyncMode(RunMode):
         else:
             logger.info("Downloading current metadata set from AMO")
             self.meta = md.Metadata(filename=md.get_metadata_file(self.args),
-                                    data=amo.download_metadata(), webext_only=True)
+                                    data=amo.download_metadata(page_size=100), webext_only=True)
             self.meta.save()
         logger.info("Metadata set contains %d web extensions" % len(self.meta))
         logger.info("Downloading missing web extensions")

--- a/webextaware/modes/unzip.py
+++ b/webextaware/modes/unzip.py
@@ -23,17 +23,16 @@ class UnzipMode(RunMode):
     def setup_args(parser):
         parser.add_argument("-o", "--outdir",
                             action="store",
-                            default="./ext",
-                            help="root path for extraction (default: ./ext)")
+                            default="ext",
+                            help="root path for extraction (default: $PWD/ext)")
 
         parser.add_argument("selectors",
                             metavar="selector",
                             nargs="+",
-                            action="append",
-                            help="AMO IDs, extension IDs, regexp, `all`, `orphans`")
+                            help="AMO IDs, extension IDs, regexp, `orphans`, `all`")
 
     def run(self):
-        exts = self.db.get_ext(self.args.selectors[0])
+        exts = self.db.get_ext(self.args.selectors)
         if len(exts) == 0:
             logger.warning("No results")
             return 10

--- a/webextaware/package.json
+++ b/webextaware/package.json
@@ -4,6 +4,7 @@
   "description": "Dummy package for installing webextaware node dependencies",
   "dependencies": {
     "eslint-config-scanjs": "mozfreddyb/eslint-config-scanjs",
+    "eslint-plugin-no-unsafe-innerhtml": "*",
     "eslint": "3",
     "retire": "^1.3.1"
   },

--- a/webextaware/package.json
+++ b/webextaware/package.json
@@ -1,12 +1,12 @@
 {
   "name": "webextaware",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Dummy package for installing webextaware node dependencies",
   "dependencies": {
     "eslint-config-scanjs": "mozfreddyb/eslint-config-scanjs",
-    "eslint-plugin-no-unsafe-innerhtml": "*",
-    "eslint": "3",
-    "retire": "^1.3.1"
+    "eslint-plugin-no-unsafe-innerhtml": "1.0",
+    "eslint": "4.6",
+    "retire": "1.4"
   },
   "devDependencies": {},
   "scripts": {

--- a/webextaware/webext.py
+++ b/webextaware/webext.py
@@ -82,16 +82,18 @@ class WebExtension(object):
                 matches.append(file_name)
         return matches
 
-    def grep(self, grep_args, color=False):
+    def grep(self, regexp, grep_args=None, color=False):
         if self.grep_exe is None:
             logger.critical("Can't find the `grep` binary.")
             return None
+        if grep_args is None:
+            grep_args = []
         if color:
             color_arg = ["--color=always"]
         else:
             color_arg = ["--color=never"]
         folder = self.unzip()
-        cmd = [self.grep_exe, "-E"] + color_arg + grep_args + ["-r", folder]
+        cmd = [self.grep_exe, "-E"] + [regexp] + grep_args + color_arg + ["-r", folder]
         logger.debug("Running shell command `%s`" % " ".join(cmd))
         grep_result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if grep_result.stderr is not None and len(grep_result.stderr) > 0:


### PR DESCRIPTION
* Adding a new `libs` subcommand for library statistics
* Parallelizing `grep` and `scan` for a massive performance boost
* Unifying selector arguments across subcommands
* Making package name selectors IGNORECASE
* Making `grep` arguments compatible to the rest
* Adding new eslint plugin node dependency
* Bumping node dependencies' versions
* Version bump to v1.2.0