### PR TITLE
Hardening grep command against decoding errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup, find_packages
 
 PACKAGE_NAME = "webextaware"
-PACKAGE_VERSION = "1.2.1"
+PACKAGE_VERSION = "1.2.2"
 
 INSTALL_REQUIRES = [
     "coloredlogs",

--- a/webextaware/webext.py
+++ b/webextaware/webext.py
@@ -101,7 +101,12 @@ class WebExtension(object):
         if grep_result.stdout is None or len(grep_result.stdout) == 0:
             return []
         results = []
-        for line in grep_result.stdout.decode("utf-8").splitlines():
+        try:
+            decoded_result = grep_result.stdout.decode("utf-8")
+        except UnicodeDecodeError as err:
+            logger.warning("Error decoding grep results in `%s`: %s" % (self.unzip_folder, err))
+            return results
+        for line in decoded_result.splitlines():
             if line.startswith(folder):
                 results.append(line.replace(folder, "<%= PACKAGE_ID %>"))
             elif line.startswith("Binary file ") and line.endswith(" matches"):


### PR DESCRIPTION
Unfortunately there are a few broken encodings out there that run the grep output parser into a unicode decode error. Note that the bug only shows when the output does not go to a terminal.