### PR TITLE
Working around API search limits

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup, find_packages
 
 PACKAGE_NAME = "webextaware"
-PACKAGE_VERSION = "1.2.1"
+PACKAGE_VERSION = "1.2.2"
 
 INSTALL_REQUIRES = [
     "coloredlogs",

--- a/tests/amo_test.py
+++ b/tests/amo_test.py
@@ -16,7 +16,7 @@ def test_amo_metadata_downloader():
     # Operates on data pre-downloaded by tests.__init__.setup_package()
     meta = tests.raw_meta
     assert_true(type(meta) is list and type(meta[0]) is dict, "delivers expected format")
-    assert_equal(len(meta), 50, "delivers expected number of extensions")
+    assert_equal(len(meta), 100, "delivers expected number of extensions")
     assert_true("id" in meta[0] and "current_version" in meta[0] and "files" in meta[0]["current_version"],
                 "metadata entries have expected format")
     assert_true(meta[0]["current_version"]["files"][0]["hash"].startswith("sha256:"), "hashes are SHA256")

--- a/webextaware/metadata.py
+++ b/webextaware/metadata.py
@@ -15,6 +15,13 @@ def get_metadata_file(args):
     return os.path.join(args.workdir, "amo_metadata.json.bz2")
 
 
+def create_directory_path(amo_id, ext_id, base=None):
+    if base is None:
+        return os.path.join(amo_id, ext_id)
+    else:
+        return os.path.join(base, amo_id, ext_id)
+
+
 class Metadata(object):
     def __init__(self, filename=None, data=None, webext_only=True):
         self.__ext = []

--- a/webextaware/modes/sync.py
+++ b/webextaware/modes/sync.py
@@ -33,9 +33,9 @@ class SyncMode(RunMode):
         else:
             logger.info("Downloading current metadata set from AMO")
             self.meta = md.Metadata(filename=md.get_metadata_file(self.args),
-                                    data=amo.download_metadata(page_size=100), webext_only=True)
+                                    data=amo.download_metadata(), webext_only=True)
             self.meta.save()
-        logger.info("Metadata set contains %d web extensions" % len(self.meta))
+        logger.info("Downloaded metadata set contains %d web extensions" % len(self.meta))
         logger.info("Downloading missing web extensions")
         amo.update_files(self.meta, self.files)
         return 0

--- a/webextaware/modes/unzip.py
+++ b/webextaware/modes/unzip.py
@@ -2,11 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import glob
 import logging
 import os
+from shutil import rmtree
 
 from .runmode import RunMode
-
+from ..metadata import create_directory_path
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +28,10 @@ class UnzipMode(RunMode):
                             default="ext",
                             help="root path for extraction (default: $PWD/ext)")
 
+        parser.add_argument("-p", "--prune",
+                            action="store_true",
+                            help="delete obsolete (unreferenced) extensions from outdir")
+
         parser.add_argument("selectors",
                             metavar="selector",
                             nargs="+",
@@ -39,10 +45,17 @@ class UnzipMode(RunMode):
 
         for amo_id in exts:
             for ext_id in exts[amo_id]:
-                unzip_path = os.path.join(self.args.outdir, str(amo_id), ext_id)
+                unzip_path = create_directory_path(str(amo_id), ext_id, base=self.args.outdir)
                 os.makedirs(unzip_path, exist_ok=True)
                 with exts[amo_id][ext_id] as ext:
                     ext.unzip(unzip_path)
                 print(unzip_path)
+
+        if self.args.prune:
+            logger.info("Pruning orphans from output directory")
+            for ext_id in self.db.get_ext("orphans")[0]:
+                for match in glob.glob(create_directory_path("*", ext_id, base=self.args.outdir)):
+                    logger.info("Pruning `%s`" % match)
+                    rmtree(match)
 
         return 0


### PR DESCRIPTION
The search query used for listing all web extensions on AMO has been running into the 500 result pages limit of the AMO API. Working around this by stricter filtering, getting us below 200 result pages again with some headroom to come.