### PR TITLE
Fix error in nooverwrite handler; follow-up to #28

### DIFF
--- a/webextaware/modes/unzip.py
+++ b/webextaware/modes/unzip.py
@@ -55,7 +55,7 @@ class UnzipMode(RunMode):
                     os.makedirs(unzip_path, exist_ok=False)
                 except FileExistsError:
                     if self.args.nooverwrite:
-                        logger.Info("Skipping existing directory %s" % unzip_path)
+                        logger.info("Skipping existing directory %s" % unzip_path)
                         continue
                 with exts[amo_id][ext_id] as ext:
                     ext.unzip(unzip_path)


### PR DESCRIPTION
`logger.info` was misspelled as `logger.Info`, which caused the following error:

```
$ webextaware unzip all --nooverwrite -o /path/to/outdir
...
Traceback (most recent call last):
  File "/home/webextaware/.local/lib/python3.7/site-packages/webextaware/modes/unzip.py", line 55, in run
    os.makedirs(unzip_path, exist_ok=False)
  File "/usr/lib/python3.7/os.py", line 221, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/path/to/outdir/<id>/<hash>'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/webextaware/.local/bin/webextaware", line 11, in <module>
    load_entry_point('webextaware==1.2.4', 'console_scripts', 'webextaware')()
  File "/home/webextaware/.local/lib/python3.7/site-packages/webextaware/main.py", line 78, in main
    result = modes.run(args)
  File "/home/webextaware/.local/lib/python3.7/site-packages/webextaware/modes/runmode.py", line 131, in run
    result = current_mode.run()
  File "/home/webextaware/.local/lib/python3.7/site-packages/webextaware/modes/unzip.py", line 58, in run
    logger.Info("Skipping existing directory %s" % unzip_path)
AttributeError: 'Logger' object has no attribute 'Info'
```