### PR TITLE
Avoid hardcoded AMO API limits & migrate to AMO API v5

### DIFF
--- a/tests/amo_test.py
+++ b/tests/amo_test.py
@@ -8,9 +8,9 @@ def test_amo_metadata_downloader(raw_meta):
     # Operates on data pre-downloaded by tests.__init__.setup_package()
     assert type(raw_meta) is list and type(raw_meta[0]) is dict, "delivers expected format"
     assert len(raw_meta) == 100, "delivers expected number of extensions"
-    assert "id" in raw_meta[0] and "current_version" in raw_meta[0] and "files" in raw_meta[0]["current_version"], \
+    assert "id" in raw_meta[0] and "current_version" in raw_meta[0] and "file" in raw_meta[0]["current_version"], \
         "metadata entries have expected format"
-    assert raw_meta[0]["current_version"]["files"][0]["hash"].startswith("sha256:"), "hashes are SHA256"
+    assert raw_meta[0]["current_version"]["file"]["hash"].startswith("sha256:"), "hashes are SHA256"
 
 
 def test_amo_extension_downloader(raw_meta, ext_db):
@@ -20,10 +20,9 @@ def test_amo_extension_downloader(raw_meta, ext_db):
     # Download AMO pages until they contain at least five web extension files
     all_extensions = set()
     for ext in raw_meta:
-        for f in ext["current_version"]["files"]:
-            if f["is_webextension"]:
-                h = f["hash"].split(":")[1]
-                all_extensions.add(h)
+        f = ext["current_version"]["file"]
+        h = f["hash"].split(":")[1]
+        all_extensions.add(h)
 
     # See which extensions were actually downloaded
     downloaded_extensions = set()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import hashfs
 import pytest
 
 from webextaware import amo
+from webextaware import metadata as md
 
 
 @pytest.fixture(scope="session")
@@ -23,5 +24,6 @@ def hfs_tmp(tmpdir_factory):
 @pytest.fixture(scope="session")
 def ext_db(raw_meta, hfs_tmp):
     edb = hashfs.HashFS(hfs_tmp, depth=4, width=1, algorithm='sha256')
-    amo.update_files(raw_meta, edb)
+    meta = md.Metadata(data=raw_meta)
+    amo.update_files(meta, edb)
     return edb

--- a/webextaware/amo.py
+++ b/webextaware/amo.py
@@ -18,7 +18,7 @@ def download_metadata(max_pages=(2 << 31), max_ext=(2 << 31), page_size=50):
     global logger
 
     # Maximum page_size seems to be 50 right now, 25 is AMO's current default.
-    url = amo_server + "/api/v3/addons/search/"
+    url = amo_server + "/api/v5/addons/search/"
     search_params = "sort=created" \
         "&type=extension" \
         "&app=firefox" \
@@ -82,9 +82,7 @@ def __as_chunks(flat_list, chunk_size):
 def update_files(metadata, hash_fs):
     urls_to_get = []
     for ext in metadata:
-        for ext_file in ext["current_version"]["files"]:
-            if not ext_file["is_webextension"]:
-                continue
+        for ext_file in ext.files():
             ext_file_hash_type, ext_file_hash = ext_file["hash"].split(":")
             assert ext_file_hash_type == "sha256"
             if hash_fs.get(ext_file_hash) is None:

--- a/webextaware/amo.py
+++ b/webextaware/amo.py
@@ -22,7 +22,6 @@ def download_metadata(max_pages=(2 << 31), max_ext=(2 << 31), page_size=50):
     search_params = "sort=created" \
         "&type=extension" \
         "&app=firefox" \
-        "&appversion=" + ",".join(map(str, range(57, 75))) + \
         "&page_size=%d" % page_size
     logger.debug("Search parameters for AMO query: %s" % search_params)
 

--- a/webextaware/amo.py
+++ b/webextaware/amo.py
@@ -32,9 +32,11 @@ def download_metadata(max_pages=(2 << 31), max_ext=(2 << 31), page_size=50):
     if page_size != supported_page_size:
         logger.warning("Requested size %d is greater than supported size %d" % (page_size, supported_page_size))
     num_pages = min(max_pages, int(math.ceil(first_page["count"] / supported_page_size)))
-    if num_pages > 500:
-        logger.warning("Truncating results to 500 pages (25000 results) due to API limitation")
-        num_pages = 500
+    max_pages_in_api = first_page["page_count"]
+    if num_pages > max_pages_in_api:
+        actual_result_count = max_pages_in_api * supported_page_size
+        logger.warning("Truncating results to %d pages (%d results) due to API limitation" % (max_pages_in_api, actual_result_count))
+        num_pages = max_pages_in_api
     logger.info("Fetching %d pages of AMO metadata" % num_pages)
     pages_to_get = ["%s?%s&page=%d" % (url, search_params, n) for n in range(2, num_pages + 1)]
 

--- a/webextaware/amo.py
+++ b/webextaware/amo.py
@@ -14,7 +14,15 @@ amo_server = "https://addons.mozilla.org"
 MAX_CONCURRENT_REQUESTS = 10
 
 
-def download_metadata(max_pages=(2 << 31), max_ext=(2 << 31), page_size=50):
+def download_metadata(max_pages=(2 << 31), max_ext=(2 << 31), page_size=50, min_users=0, max_users=0):
+    """
+    Retrieves the metadata for all public extensions.
+    If specified, limit to extensions with at least |min_users| users.
+    If specified, limit to extensions with less than |max_users| users.
+
+    Returns an array of addon results from the AMO API as described at
+    https://addons-server.readthedocs.io/en/latest/topics/api/addons.html#addon-detail-object
+    """
     global logger
 
     # Maximum page_size seems to be 50 right now, 25 is AMO's current default.
@@ -23,11 +31,23 @@ def download_metadata(max_pages=(2 << 31), max_ext=(2 << 31), page_size=50):
         "&type=extension" \
         "&app=firefox" \
         "&page_size=%d" % page_size
+    if min_users:
+        search_params += "&users__gte=%d" % min_users
+    if max_users:
+        search_params += "&users__lt=%d" % max_users
     logger.debug("Search parameters for AMO query: %s" % search_params)
+
+    extra_desc = ""
+    if min_users and max_users:
+        extra_desc += ", with at least %d and less than %d users" % (min_users, max_users)
+    elif min_users:
+        extra_desc += ", with at least %d users" % min_users
+    elif max_users:
+        extra_desc += ", with less than %d users" % max_users
 
     # Grab page_size and count from first result page and calculate num_pages from that
     first_page = requests.get("%s?%s" % (url, search_params), verify=True).json()
-    logger.info("There are currently %d web extensions listed" % first_page["count"])
+    logger.info("There are currently %d web extensions listed%s" % (first_page["count"], extra_desc))
     supported_page_size = int(first_page["page_size"])
     if page_size != supported_page_size:
         logger.warning("Requested size %d is greater than supported size %d" % (page_size, supported_page_size))
@@ -35,10 +55,17 @@ def download_metadata(max_pages=(2 << 31), max_ext=(2 << 31), page_size=50):
     max_pages_in_api = first_page["page_count"]
     if num_pages > max_pages_in_api:
         actual_result_count = max_pages_in_api * supported_page_size
+        if not min_users and not max_users and num_pages <= max_pages and first_page["count"] < max_ext:
+            logger.info("Splitting query to avoid truncation to %d results" % actual_result_count)
+            return download_metadata_workaround_limit(max_pages, max_ext, supported_page_size, first_page["count"])
         logger.warning("Truncating results to %d pages (%d results) due to API limitation" % (max_pages_in_api, actual_result_count))
         num_pages = max_pages_in_api
     logger.info("Fetching %d pages of AMO metadata" % num_pages)
     pages_to_get = ["%s?%s&page=%d" % (url, search_params, n) for n in range(2, num_pages + 1)]
+
+    # NOTE: The logic below assumes the result set to be stable during the query.
+    # If an item is deleted during the query, another item may be missing or
+    # appear multiple times due to shifted items during pagination.
 
     session = create_request_session()
     metadata = first_page["results"]
@@ -71,6 +98,45 @@ def download_metadata(max_pages=(2 << 31), max_ext=(2 << 31), page_size=50):
     if len(metadata) != first_page["count"]:
         logger.warning("Got %d instead of the expected %d results" % (len(metadata), first_page["count"]))
 
+    return metadata[0:min(len(metadata), max_ext)]
+
+
+def download_metadata_workaround_limit(max_pages, max_ext, page_size, total_count):
+    global logger
+
+    # The AMO API is limited to 30k, but there are more extensions. To work
+    # around this limit, we run two queries with logically disjoint results and
+    # merge them. In May 2023, the total number of public extensions is 32k,
+    # of which 14k have at least 10 users (=user_count_for_split).
+    #
+    # The work-around here depends on the ability to partition the results in
+    # subsets. Ideally the AMO API should not have a cap on the result window:
+    # https://github.com/mozilla/addons-server/issues/20640
+    user_count_for_split = 10
+    logger.info("Part 1 of 2: Looking up extensions with at least %d users" % user_count_for_split)
+    metadata_part_1 = download_metadata(max_pages, max_ext, page_size, user_count_for_split, 0)
+    logger.info("Part 2 of 2: Looking up extensions with less than %d users" % user_count_for_split)
+    metadata_part_2 = download_metadata(max_pages, max_ext, page_size, 0, user_count_for_split)
+    logger.info("Merging %d and %d and expecting %d results" % (len(metadata_part_1), len(metadata_part_2), total_count))
+
+    id_seen = set()
+    metadata = []
+    for metadata_part in [metadata_part_1, metadata_part_2]:
+        for ext in metadata_part:
+            amo_id = ext["id"]
+            if amo_id in id_seen:
+                # In theory, the user count could update while the query is
+                # running, and an addon can appear in both lists.
+                logger.warning("Ignoring duplicate entry for AMO ID %s (addon ID %s)" % (amo_id, ext["guid"]))
+                continue
+            id_seen.add(amo_id)
+            metadata.append(ext)
+
+    if len(metadata) != total_count:
+        # Could happen for several reasons, including but not limited to:
+        # - An extension was added or removed while querying.
+        # - user count updated, extension no longer in metadata_part_2.
+        logger.warning("Got %d instead of the expected %d results after combining two result sets" % (len(metadata), total_count))
     return metadata[0:min(len(metadata), max_ext)]
 
 

--- a/webextaware/database.py
+++ b/webextaware/database.py
@@ -38,7 +38,7 @@ class Database(object):
         else:
             logger.info("Downloading current metadata set from AMO")
             self.meta = md.Metadata(filename=md.get_metadata_file(self.args),
-                                    data=amo.download_metadata(), webext_only=True)
+                                    data=amo.download_metadata())
             self.meta.save()
         logger.info("Metadata set contains %d web extensions" % len(self.meta))
         logger.info("Downloading missing web extensions")

--- a/webextaware/modes/sync.py
+++ b/webextaware/modes/sync.py
@@ -33,7 +33,7 @@ class SyncMode(RunMode):
         else:
             logger.info("Downloading current metadata set from AMO")
             self.meta = md.Metadata(filename=md.get_metadata_file(self.args),
-                                    data=amo.download_metadata(), webext_only=True)
+                                    data=amo.download_metadata())
             self.meta.save()
         logger.info("Downloaded metadata set contains %d web extensions" % len(self.meta))
         logger.info("Downloading missing web extensions")


### PR DESCRIPTION
The current `webextaware` tool does not download all public extensions, for multiple reasons (each reason has its separate commit with a detailed commit message):

- Only extensions compatible with 57 - 75 are returned (reminder: we're at Firefox 112 right now): https://github.com/cr/webextaware/blob/2b7e01a7ae799a323b166c16b3f65d7e772dfe3d/webextaware/amo.py#L25
- There is a hardcoded limit of 25k based on AMO's original API limit. The limit today is 30k. I have removed the hard-coded limit in favor of computing it dynamically based on the API response. https://github.com/cr/webextaware/blob/2b7e01a7ae799a323b166c16b3f65d7e772dfe3d/webextaware/amo.py#L36-L38
- The next feature depends on [the "users" parameter of AMO API v5](https://github.com/mozilla/addons/issues/8406), so I have migrated the code to AMO v5. It was using AMO API v3, which [has been deprecated and is "available until at least 31st December 2021."](https://addons-server.readthedocs.io/en/latest/topics/api/overview.html#deprecated-v3-api)
- The 30k limit is not enough; there are 32k extensions currently. I introduced a work-around to still download the full set of extensions, consisting of splitting the query in two disjoint sets. In theory the technique can be generalized to more than two queries, but in practice that will eventually hit a limit as well (when we cannot split the queries further). The "real" fix for truly unlimited queries would have to be in AMO, for which I filed a request at https://github.com/mozilla/addons/issues/1930

Verified by running `pytest`, and by running the tool manually:
<details> 
  <summary>Output of <code>webextaware sync</code></summary>

```
$ webextaware sync
2023-05-03 19:28:02 INFO MainThread webextaware.modes.sync Downloading current metadata set from AMO
2023-05-03 19:28:03 INFO MainThread webextaware.amo There are currently 31574 web extensions listed
2023-05-03 19:28:03 INFO MainThread webextaware.amo Splitting query to avoid truncation to 30000 results
2023-05-03 19:28:03 INFO MainThread webextaware.amo Part 1 of 2: Looking up extensions with at least 10 users
2023-05-03 19:28:03 INFO MainThread webextaware.amo There are currently 14091 web extensions listed, with at least 10 users
2023-05-03 19:28:03 INFO MainThread webextaware.amo Fetching 282 pages of AMO metadata
2023-05-03 19:28:04 INFO MainThread webextaware.amo 275 pages to go
2023-05-03 19:28:05 INFO MainThread webextaware.amo 250 pages to go
2023-05-03 19:28:06 INFO MainThread webextaware.amo 225 pages to go
2023-05-03 19:28:07 INFO MainThread webextaware.amo 200 pages to go
2023-05-03 19:28:08 INFO MainThread webextaware.amo 175 pages to go
2023-05-03 19:28:10 INFO MainThread webextaware.amo 150 pages to go
2023-05-03 19:28:11 INFO MainThread webextaware.amo 125 pages to go
2023-05-03 19:28:12 INFO MainThread webextaware.amo 100 pages to go
2023-05-03 19:28:13 INFO MainThread webextaware.amo 75 pages to go
2023-05-03 19:28:14 INFO MainThread webextaware.amo 50 pages to go
2023-05-03 19:28:15 INFO MainThread webextaware.amo 25 pages to go
2023-05-03 19:28:16 INFO MainThread webextaware.amo 0 pages to go
2023-05-03 19:28:16 INFO MainThread webextaware.amo Part 2 of 2: Looking up extensions with less than 10 users
2023-05-03 19:28:17 INFO MainThread webextaware.amo There are currently 17483 web extensions listed, with less than 10 users
2023-05-03 19:28:17 INFO MainThread webextaware.amo Fetching 350 pages of AMO metadata
2023-05-03 19:28:19 INFO MainThread webextaware.amo 325 pages to go
2023-05-03 19:28:20 INFO MainThread webextaware.amo 300 pages to go
2023-05-03 19:28:21 INFO MainThread webextaware.amo 275 pages to go
2023-05-03 19:28:22 INFO MainThread webextaware.amo 250 pages to go
2023-05-03 19:28:24 INFO MainThread webextaware.amo 225 pages to go
2023-05-03 19:28:25 INFO MainThread webextaware.amo 200 pages to go
2023-05-03 19:28:26 INFO MainThread webextaware.amo 175 pages to go
2023-05-03 19:28:27 INFO MainThread webextaware.amo 150 pages to go
2023-05-03 19:28:29 INFO MainThread webextaware.amo 125 pages to go
2023-05-03 19:28:30 INFO MainThread webextaware.amo 100 pages to go
2023-05-03 19:28:31 INFO MainThread webextaware.amo 75 pages to go
2023-05-03 19:28:33 INFO MainThread webextaware.amo 50 pages to go
2023-05-03 19:28:34 INFO MainThread webextaware.amo 25 pages to go
2023-05-03 19:28:36 INFO MainThread webextaware.amo 0 pages to go
2023-05-03 19:28:36 INFO MainThread webextaware.amo Merging 14091 and 17483 and expecting 31574 results
2023-05-03 19:28:55 INFO MainThread webextaware.modes.sync Downloaded metadata set contains 31574 web extensions
2023-05-03 19:28:55 INFO MainThread webextaware.modes.sync Downloading missing web extensions
```
</details>
